### PR TITLE
Add comprehensive analysis docs for Claude Code

### DIFF
--- a/docs/01_overview.md
+++ b/docs/01_overview.md
@@ -1,0 +1,19 @@
+# Claude Code Overview
+
+@anthropic-ai/claude-code is a terminal-based coding assistant published as an npm package. After a global install, the `claude` command launches an interactive agent that understands a repository, edits files and executes commands through natural language.
+
+The package is distributed with a small set of top-level assets:
+
+- `cli.js` – entry point for the CLI interface
+- `sdk.mjs` and TypeScript definition files for programmatic access
+- `vendor/` and `node_modules/` directories containing bundled dependencies
+- `yoga.wasm` for layout rendering
+
+Running `npm install -g @anthropic-ai/claude-code` adds the command to the global path and exposes the exported APIs for Node.js applications.
+
+The project exposes a CLI and an SDK. The CLI renders a terminal UI, displays messages, and invokes tools to fulfill user requests. The SDK provides a `query` function that streams messages from a spawned CLI process and enables external programs to integrate Claude Code behavior.
+
+Agent sessions begin with a concise system prompt identifying the tool: "You are Claude Code, Anthropic's official CLI for Claude." The agent can read and modify files, run shell commands, fetch web content, search documentation, and interact with Model Context Protocol (MCP) servers.
+
+Each tool invocation and major event flows through a permission and hook system that allows customization or auditing. The package defaults to Node 18+, includes zero direct dependencies, and relies on optional `sharp` builds per platform for image manipulation tasks.
+

--- a/docs/02_sdk_and_transport.md
+++ b/docs/02_sdk_and_transport.md
@@ -1,0 +1,19 @@
+# SDK and Transport Layer
+
+The SDK entry point `sdk.mjs` exports a `query` function that orchestrates an interactive session with the Claude Code CLI. The function accepts a prompt (string or streaming iterable) and an options object. Internally it spawns `cli.js` as a child process using the `ProcessTransport` abstraction, piping JSON messages between processes.
+
+Key utilities in the SDK include:
+
+* **Stream** – an async iterator implementation that queues messages and supports `done` and `error` signals.
+* **createAbortController** – constructs abort controllers with raised listener limits to support many concurrent hooks.
+* **ProcessTransport** – wraps `child_process.spawn`, forwarding stdin/stdout and encoding messages as newline-delimited JSON.
+
+The `query` function sets up environment variables and determines the executable (`node` or `bun`). It also configures permission mode, allowed/disallowed tools, model selection, and optional custom system prompts before spawning the transport. If the prompt is an async iterator, the SDK operates in streaming mode and feeds user messages to the transport incrementally.
+
+Returned from `query` is a `Query` object that implements `AsyncGenerator<SDKMessage, void>`. It yields structured messages representing system, user, assistant, or result events. The object exposes helper methods:
+
+* `interrupt()` – cancel a streaming query
+* `setPermissionMode()` – adjust permission enforcement while streaming
+
+The `Query` class also handles control requests from the CLI, such as asking whether a tool may be executed or invoking hook callbacks supplied in the options. Messages are processed through an internal `Stream` instance and surfaced to consumers via async iteration.
+

--- a/docs/03_tool_schema.md
+++ b/docs/03_tool_schema.md
@@ -1,0 +1,16 @@
+# Tool Input Schemas
+
+Claude Code defines its tool interface through a comprehensive TypeScript declaration file `sdk-tools.d.ts`. This schema enumerates every tool that the agent may invoke along with the expected input fields and validation rules. The tools include:
+
+- **Agent** – delegate tasks to specialized subagents with a short description and prompt.
+- **Bash** and **BashOutput** – execute shell commands and read output from background processes, with optional sandbox mode, timeouts and regex filtering.
+- **FileEdit** and **FileMultiEdit** – modify existing files via precise string replacement operations, supporting atomic multi-edit batches.
+- **FileRead** and **FileWrite** – read or overwrite files using absolute paths. Reads support paging with offsets and limits.
+- **Glob**, **Grep**, and **Ls** – search the filesystem using patterns, regular expressions, and directory listing primitives.
+- **NotebookEdit** – manipulate Jupyter notebooks by editing or inserting cells.
+- **WebFetch** and **WebSearch** – retrieve web content or execute internet searches with domain filtering and post-processing prompts.
+- **TodoWrite** – maintain a structured todo list.
+- **KillShell**, **ListMcpResources**, **ReadMcpResource**, and generic **Mcp** requests for interacting with Model Context Protocol servers.
+
+Every schema documents required types, optional fields, and special usage notes such as sandboxing rules, maximum lengths, or error conditions. These definitions are auto-generated from JSON Schema sources, ensuring strict validation before tools execute.
+

--- a/docs/04_file_tools.md
+++ b/docs/04_file_tools.md
@@ -1,0 +1,24 @@
+# File Manipulation Tools
+
+Claude Code offers several tools for inspecting and mutating files in a repository. These tools operate on absolute paths and expect the caller to read files before attempting writes.
+
+## FileRead
+Reads a file from the local filesystem. It requires a `file_path` and optionally supports `offset` and `limit` for paginated access when files are too large to load at once.
+
+## FileWrite
+Writes content to an absolute `file_path`. If the file exists it will be overwritten. The CLI emphasizes that existing files should be edited rather than replaced and warns against creating documentation unless explicitly requested by the user.
+
+## FileEdit
+Replaces a single string within a file. Inputs include `file_path`, `old_string`, `new_string`, and optional `replace_all` to change every occurrence. The operation fails if `old_string` does not match the file's current contents exactly or if `old_string` and `new_string` are identical.
+
+## FileMultiEdit
+Applies a sequence of edits to one file atomically. Each edit specifies `old_string`, `new_string`, and optional `replace_all`. All edits must succeed or none are applied. The bundled instructions stress reading the file first and ensuring earlier edits do not interfere with later ones.
+
+## Glob and Grep
+`Glob` searches for files matching a pattern optionally rooted at a `path`. `Grep` leverages ripgrep-style options including `--glob` filters, context lines (`-A`, `-B`, `-C`), line numbers (`-n`), case insensitivity (`-i`), file type constraints, and output modes (`content`, `files_with_matches`, `count`). Both tools support `head_limit` to cap results.
+
+## Ls
+Lists the contents of a directory at an absolute `path`, with optional glob patterns to ignore. This is used to understand project structure before editing.
+
+Together, these tools enable the agent to analyze and modify codebases while maintaining strict validation to prevent accidental corruption or unauthorized writes.
+

--- a/docs/05_shell_and_process_tools.md
+++ b/docs/05_shell_and_process_tools.md
@@ -1,0 +1,27 @@
+# Shell and Process Tools
+
+The CLI integrates tightly with the local shell, allowing the agent to run commands, capture output and manage long-running processes.
+
+## Bash
+Executes a command string using the system shell. Inputs allow:
+
+- `command` – the literal shell command
+- `timeout` – optional milliseconds before termination (max 600000)
+- `description` – a concise explanation for the user
+- `run_in_background` – run without blocking and retrieve output later
+- `sandbox` – restrict writes and network access for safer inspection
+- `shellExecutable` – override the default shell (primarily for tests)
+
+The command description is used to present context to the user when permission is requested.
+
+## BashOutput
+Retrieves buffered stdout from a background shell created with `run_in_background`. It requires the `bash_id` of the process and can optionally filter lines with a regular expression. Non-matching lines are discarded once read, preventing indefinite accumulation.
+
+## KillShell
+Terminates a background shell by its `shell_id`. This is necessary to clean up stray processes that were started but no longer needed.
+
+## NotebookEdit
+Provides structured editing of Jupyter notebook files. It accepts a `notebook_path`, optional `cell_id`, new `source` code, cell type (`code` or `markdown`), and an `edit_mode` of `replace`, `insert`, or `delete`. The tool ensures notebook JSON is updated correctly without manual manipulation.
+
+These process-oriented tools give Claude Code the ability to explore a codebase, execute tests or linters, and incorporate results back into the conversation while keeping user approval and safety at the forefront.
+

--- a/docs/06_web_tools.md
+++ b/docs/06_web_tools.md
@@ -1,0 +1,17 @@
+# Web and Research Tools
+
+Claude Code can reach beyond the local repository using two web-oriented utilities.
+
+## WebFetch
+Fetches a URL, converts HTML to markdown and applies a small model to answer a prompt about the page. Inputs:
+
+- `url` – fully formed HTTP(S) address, automatically upgraded to HTTPS when possible
+- `prompt` – instructions describing what information to extract from the fetched content
+
+Responses may be summarized when content is large. The tool maintains a 15‑minute cache and informs the user if the request redirects to a different host. The CLI warns that MCP-provided fetch tools should be preferred when available.
+
+## WebSearch
+Performs web searches to provide up‑to‑date information. Options include `allowed_domains` and `blocked_domains` for domain filtering. Results come back as structured search blocks and may be constrained to US availability. When building queries, the agent accounts for the current date to ensure timely results.
+
+These tools enrich the agent's capabilities by providing access to external knowledge and content analysis while respecting domain restrictions and user oversight.
+

--- a/docs/07_permissions_and_hooks.md
+++ b/docs/07_permissions_and_hooks.md
@@ -1,0 +1,17 @@
+# Permissions and Hooks
+
+Claude Code enforces a permission system around tool usage. The SDK's options allow specifying a `permissionMode`:
+
+- `default` – request approval for actions that may modify the system
+- `acceptEdits` – automatically apply file edits after preview
+- `bypassPermissions` – execute without interactive confirmation
+- `plan` – produce a plan for review without executing actions
+
+A `canUseTool` callback may be provided to programmatically allow, deny, or ask for approval before executing a tool. The callback returns a `PermissionResult` that can update the tool input or deny the request with a message.
+
+Beyond permissions, the SDK defines a rich hook system. The constant `HOOK_EVENTS` enumerates trigger points such as `PreToolUse`, `PostToolUse`, `Notification`, `UserPromptSubmit`, `SessionStart`, `SessionEnd`, `Stop`, `SubagentStop`, and `PreCompact`. Each hook receives structured input describing the current session and tool invocation.
+
+Hooks are registered by event name with optional pattern matchers. When a matching event occurs, the CLI sends a `hook_callback` control request and waits for the provided function's asynchronous response. Hook outputs can influence the session by adding context, suppressing output, or stopping execution.
+
+These mechanisms let integrators audit actions, enforce policy, or extend Claude Code with custom behaviors while maintaining a tight approval loop around potentially destructive operations.
+

--- a/docs/08_prompt_and_interaction.md
+++ b/docs/08_prompt_and_interaction.md
@@ -1,0 +1,15 @@
+# System Prompts and Interaction Flow
+
+Upon startup, the CLI constructs a system prompt identifying its role: *"You are Claude Code, Anthropic's official CLI for Claude."* This instruction anchors the agent's behavior and is supplied to the underlying model with each request.
+
+Consumers of the SDK may customize prompting through two options:
+
+- `customSystemPrompt` – replaces the default instructions entirely
+- `appendSystemPrompt` – appends additional guidance while preserving the baseline rules
+
+For streaming interactions, user messages can be supplied as an `AsyncIterable`. The `Query` object exposes `interrupt()` to cancel and `setPermissionMode()` to adjust safety levels mid-conversation. When plain strings are used, the entire prompt is sent in one batch.
+
+The CLI maintains conversational context, rendering a terminal UI with real-time updates. It can detect whether new messages start a different topic and update the terminal title accordingly. User input is parsed into tool requests, which are executed only after permissions are granted or policy hooks approve them.
+
+Session transcripts are written to disk, enabling resume capability via the `resume` option. Additional directories may be supplied to expand the agent's view beyond the current working directory.
+

--- a/docs/09_mcp_integration.md
+++ b/docs/09_mcp_integration.md
@@ -1,0 +1,18 @@
+# MCP Integration
+
+Claude Code supports the Model Context Protocol (MCP) for integrating external tools and resources. Through the SDK's `mcpServers` option, clients can register servers of different transport types:
+
+- `stdio` – spawn a local process and communicate over standard I/O
+- `sse` – connect to a remote server using Server‑Sent Events
+- `http` – issue HTTP requests to a tool endpoint
+
+Each server configuration may include environment variables or headers to satisfy authentication requirements. Once connected, the CLI exposes server-provided tools alongside built-in ones, prefixed with `mcp__` in their names.
+
+The schema file defines helper tools for MCP interaction:
+
+- `ListMcpResources` – enumerates available resources on a server
+- `ReadMcpResource` – fetches the content of a specific resource
+- Generic `Mcp` requests – send arbitrary payloads to a server-defined procedure
+
+Strict configuration mode (`strictMcpConfig`) enforces that only explicitly declared servers may be used. Hook callbacks and the permission system still apply, letting integrators control which MCP operations are permitted at runtime.
+

--- a/docs/10_dependencies_and_runtime.md
+++ b/docs/10_dependencies_and_runtime.md
@@ -1,0 +1,10 @@
+# Dependencies and Runtime Environment
+
+The package targets Node.js 18 or newer. The `package.json` declares no regular dependencies, relying instead on bundled code under `vendor/` and compiled artifacts such as `yoga.wasm`. For functionality like image processing, optional platform‑specific `@img/sharp-*` packages are listed as optional dependencies; npm will attempt to install the variant that matches the host environment but the package functions without them.
+
+Development scripts are intentionally locked down. The `prepare` script aborts direct `npm publish` attempts unless a specific environment variable is set, guiding contributors to internal release tooling.
+
+At runtime, the CLI spawns subprocesses via Node's `child_process` module and interacts with the filesystem using `fs` and `fs/promises`. The terminal interface adjusts to window size changes and sets the title using escape sequences. A Wasm build of the Yoga layout engine assists with rendering complex layouts.
+
+Since the package is primarily distributed as compiled JavaScript, the source code is minified and accompanied by TypeScript declaration files for external use. The authors note in the headers that unminified source is not bundled, hinting at an internal build pipeline.
+


### PR DESCRIPTION
## Summary
- install `@anthropic-ai/claude-code` and document its architecture
- add ten detailed markdown files explaining the SDK, tools, permissions, prompts, and runtime

## Testing
- `npm list -g --depth 0`

------
https://chatgpt.com/codex/tasks/task_e_68a6866c16c4832cb60d9ae410e63aa4